### PR TITLE
Интеграция бесконечного скролла

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+*.DS_Store
 .docz
 .vscode
 dist

--- a/README.md
+++ b/README.md
@@ -183,6 +183,64 @@ class App extends Component {
 ReactDOM.render(<App />, document.getElementById("react-div"));
 ```
 
+## Infinite scroll
+
+Here is a example of using material-table with infinite scroll.
+For activating infinite scroll you need to set `maxBodyHeight` less than height of page of content and set `paging: infinite`. Also, you can use callback function `onChangePage` instead of data function, which will be usefull for integration with Redux store.
+
+```jsx
+import React, { Component } from "react";
+import ReactDOM from "react-dom";
+import MaterialTable from "material-table";
+
+class App extends Component {
+  render() {
+    return (
+      <div style={{ maxWidth: "100%" }}>
+          <MaterialTable
+            title="Infinite Scroll Preview"
+            columns={[
+              {
+                title: 'Avatar',
+                field: 'avatar',
+                render: rowData => (
+                  <img
+                    style={{ height: 36, borderRadius: '50%' }}
+                    src={rowData.avatar}
+                  />
+                ),
+              },
+              { title: 'Id', field: 'id' },
+              { title: 'First Name', field: 'first_name' },
+              { title: 'Last Name', field: 'last_name' },
+            ]}
+            options={{
+              maxBodyHeight: 200,
+              paging: 'infinite',
+            }}
+            data={query => new Promise((resolve, reject) => {
+              let url = 'https://reqres.in/api/users?'
+              url += 'per_page=' + query.pageSize
+              url += '&page=' + (query.page + 1)
+              fetch(url)
+                .then(response => response.json())
+                .then(result => {
+                  resolve({
+                    data: result.data,
+                    page: result.page - 1,
+                    totalCount: result.total,
+                  })
+                })
+            })}
+          />
+      </div>
+    );
+  }
+}
+
+ReactDOM.render(<App />, document.getElementById("react-div"));
+```
+
 ## Contributing
 
 We'd love to have your helping hand on `material-table`! See [CONTRIBUTING.md](https://github.com/mbrn/material-table/blob/master/.github/CONTRIBUTING.md) for more information on what we're looking for and how to get started.

--- a/demo/demo.js
+++ b/demo/demo.js
@@ -239,7 +239,42 @@ const App = () => {
               let url = 'https://reqres.in/api/users?'
               url += 'per_page=' + query.pageSize
               url += '&page=' + (query.page + 1)
-              console.log(query);
+              fetch(url)
+                .then(response => response.json())
+                .then(result => {
+                  resolve({
+                    data: result.data,
+                    page: result.page - 1,
+                    totalCount: result.total,
+                  })
+                })
+            })}
+          />
+          <MaterialTable
+            title="Infinite Scroll Preview"
+            columns={[
+              {
+                title: 'Avatar',
+                field: 'avatar',
+                render: rowData => (
+                  <img
+                    style={{ height: 36, borderRadius: '50%' }}
+                    src={rowData.avatar}
+                  />
+                ),
+              },
+              { title: 'Id', field: 'id' },
+              { title: 'First Name', field: 'first_name' },
+              { title: 'Last Name', field: 'last_name' },
+            ]}
+            options={{
+              maxBodyHeight: 200,
+              paging: 'infinite',
+            }}
+            data={query => new Promise((resolve, reject) => {
+              let url = 'https://reqres.in/api/users?'
+              url += 'per_page=' + query.pageSize
+              url += '&page=' + (query.page + 1)
               fetch(url)
                 .then(response => response.json())
                 .then(result => {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@softmedialab/materialui-table",
-  "version": "1.0.48",
+  "version": "1.0.49",
   "description": "Datatable for React based on https://material-table.com with additional features",
   "main": "dist/index.js",
   "types": "types/index.d.ts",
@@ -75,6 +75,7 @@
     "@material-ui/core": "^4.0.1",
     "@material-ui/icons": "^4.2.1",
     "@material-ui/pickers": "^3.0.0",
+    "ahooks": "^2.10.9",
     "classnames": "^2.2.6",
     "date-fns": "^2.0.0-alpha.27",
     "debounce": "^1.2.0",

--- a/src/components/index.js
+++ b/src/components/index.js
@@ -9,6 +9,7 @@ import MTableEditRow from './m-table-edit-row';
 import MTableEditField from './m-table-edit-field';
 import MTableFilterRow from './m-table-filter-row';
 import MTableHeader from './m-table-header';
+import MTableInfinite from './m-table-infinite';
 import MTablePagination from './m-table-pagination';
 import MTableSteppedPagination from './m-table-stepped-pagination';
 import MTableToolbar from './m-table-toolbar';
@@ -27,6 +28,7 @@ export {
   MTableEditField,
   MTableFilterRow,
   MTableHeader,
+  MTableInfinite,
   MTablePagination,
   MTableSteppedPagination,
   MTableToolbar,

--- a/src/components/m-table-body.js
+++ b/src/components/m-table-body.js
@@ -53,7 +53,7 @@ class MTableBody extends React.Component {
         addColumn++;
       }
       return (
-        <TableRow style={{ height: 49 * (this.props.options.paging && this.props.options.emptyRowsWhenPaging ? this.props.pageSize : 1) }} key={'empty-' + 0} >
+        <TableRow style={{ height: 49 * (this.props.options.paging === 'classic' && this.props.options.emptyRowsWhenPaging ? this.props.pageSize : 1) }} key={'empty-' + 0} >
           <TableCell style={{ paddingTop: 0, paddingBottom: 0, textAlign: 'center' }} colSpan={this.props.columns.length + addColumn} key="empty-">
             {localization.emptyDataSourceMessage}
           </TableCell>
@@ -156,7 +156,7 @@ class MTableBody extends React.Component {
       .sort((col1, col2) => col1.tableData.groupOrder - col2.tableData.groupOrder);
 
     let emptyRowCount = 0;
-    if (this.props.options.paging) {
+    if (this.props.options.paging === 'classic') {
       emptyRowCount = this.props.pageSize - renderData.length;
     }
     return (

--- a/src/components/m-table-infinite.js
+++ b/src/components/m-table-infinite.js
@@ -1,0 +1,66 @@
+import React, { useEffect, useRef, useState } from 'react';
+import PropTypes from 'prop-types';
+
+import useScroll from 'ahooks/es/useScroll';
+import useSize from 'ahooks/es/useSize';
+
+export const MTableInfinite = (props) => {
+
+  const threshold = props.threshold ?? props.maxBodyHeight * 1.5;
+
+  const containerRef = useRef(null);
+  const scroll = useScroll(containerRef);
+
+  const contentRef = useRef(null);
+  const sizes = useSize(contentRef);
+
+  const [isScrolled, setScrolled] = useState(false);
+  const nextPage = props.currentPage + 1;
+
+  useEffect(() => {
+    if (
+      props.paging === 'infinite' &&
+      sizes.height > props.maxBodyHeight &&
+      props.pageSize * nextPage < props.totalCount &&
+      scroll.top > props.maxBodyHeight
+    ) {
+      if (sizes.height - (scroll.top + props.maxBodyHeight) < threshold) {
+        if (!isScrolled) {
+          setScrolled(true);
+          props.onChangePage(undefined, nextPage);
+        }
+      } else {
+        setScrolled(false);
+      }
+    }
+  }, [scroll.top, sizes.height]);
+
+  if (props.paging === 'infinite') {
+    return (
+      <div ref={containerRef} style={{ maxHeight: props.maxBodyHeight, overflowY: 'auto' }}>
+        <div ref={contentRef}>
+          {props.children}
+        </div>
+      </div>
+    );
+  }
+  else {
+    return (
+      <>
+        {props.children}
+      </>
+    );
+  }
+};
+
+MTableInfinite.propTypes = {
+  paging: PropTypes.oneOf(['classic', 'infinite', 'disabled']),
+  maxBodyHeight: PropTypes.oneOfType([PropTypes.number, PropTypes.string]),
+  threshold: PropTypes.number,
+  currentPage: PropTypes.number.isRequired,
+  pageSize: PropTypes.number.isRequired,
+  totalCount: PropTypes.number,
+  onChangePage: PropTypes.func,
+};
+
+export default MTableInfinite;

--- a/src/default-props.js
+++ b/src/default-props.js
@@ -83,7 +83,7 @@ export const defaultProps = {
     fixedColumns: 0,
     header: true,
     loadingType: 'overlay',
-    paging: true,
+    paging: 'classic',
     pageSize: 5,
     pageSizeOptions: [5, 10, 20],
     paginationType: 'normal',

--- a/src/material-table.js
+++ b/src/material-table.js
@@ -2,7 +2,7 @@
 import { Table, TableFooter, TableRow, LinearProgress } from '@material-ui/core';
 import DoubleScrollbar from "react-double-scrollbar";
 import * as React from 'react';
-import { MTablePagination, MTableSteppedPagination } from './components';
+import { MTableInfinite, MTablePagination, MTableSteppedPagination } from './components';
 import { DragDropContext, Droppable } from 'react-beautiful-dnd';
 import DataManager from './utils/data-manager';
 import { debounce } from 'debounce';
@@ -491,7 +491,7 @@ export default class MaterialTable extends React.Component {
   renderFooter() {
     const props = this.getProps();
 
-    if (props.options.paging) {
+    if (props.options.paging === 'classic') {
       const localization = { ...MaterialTable.defaultProps.localization.pagination, ...this.props.localization.pagination };
       return (
         <Table>
@@ -662,19 +662,27 @@ export default class MaterialTable extends React.Component {
               onGroupRemoved={this.onGroupRemoved}
             />
           }
+
           <ScrollBar double={props.options.doubleHorizontalScroll} tableId={this.id} ownProps={this.props}>
             <Droppable droppableId="headers" direction="horizontal">
               {(provided, snapshot) => (
                 <div ref={provided.innerRef}>
-                  <div style={{ maxHeight: props.options.maxBodyHeight, overflowY: 'auto' }}>
+                  <MTableInfinite
+                    paging={props.options.paging}
+                    maxBodyHeight={props.options.maxBodyHeight}
+                    currentPage={this.isRemoteData() ? this.state.query.page : this.state.currentPage}
+                    pageSize={this.state.pageSize}
+                    totalCount={this.isRemoteData() ? this.state.query.totalCount : this.state.data.length}
+                    onChangePage={this.onChangePage}
+                  >
                     {this.renderTable()}
-                  </div>
+                  </MTableInfinite>
                   {provided.placeholder}
                 </div>
               )}
             </Droppable>
-
           </ScrollBar>
+
           {(this.state.isLoading || props.isLoading) && props.options.loadingType === "linear" &&
             <div style={{ position: 'relative', width: '100%' }}>
               <div style={{ position: 'absolute', top: 0, left: 0, height: '100%', width: '100%' }}>

--- a/src/prop-types.js
+++ b/src/prop-types.js
@@ -142,7 +142,7 @@ export const propTypes = {
     initialPage: PropTypes.number,
     maxBodyHeight: PropTypes.oneOfType([PropTypes.number, PropTypes.string]),
     loadingType: PropTypes.oneOf(['overlay', 'linear']),
-    paging: PropTypes.bool,
+    paging: PropTypes.oneOf(['classic', 'infinite', 'disabled']),
     pageSize: PropTypes.number,
     pageSizeOptions: PropTypes.arrayOf(PropTypes.number),
     paginationType: PropTypes.oneOf(['normal', 'stepped']),

--- a/src/utils/data-manager.js
+++ b/src/utils/data-manager.js
@@ -12,7 +12,7 @@ export default class DataManager {
   orderBy = -1;
   orderDirection = '';
   pageSize = 5;
-  paging = true;
+  paging = 'classic';
   parentFunc = null;
   searchText = '';
   selectedCount = 0;
@@ -48,8 +48,8 @@ export default class DataManager {
   setData(data) {
     this.selectedCount = 0;
     let alreadyEditableRow = null;
-    this.data = data.map((row, index) => {
-      row.tableData = { ...row.tableData, id: index };
+    const dataMapped = data.map((row, index) => {
+      row.tableData = { ...row.tableData, id: index + this.data.length };
       if (row.tableData.checked) {
         this.selectedCount++;
       }
@@ -62,6 +62,11 @@ export default class DataManager {
       }
       return row;
     });
+    if (this.paging === 'infinite') {
+      this.data = this.data.concat(dataMapped);
+    } else {
+      this.data = dataMapped;
+    }
     if (alreadyEditableRow) {
       this.changeRowEditing(alreadyEditableRow, 'update');
     } else {
@@ -835,7 +840,7 @@ export default class DataManager {
   pageData() {
     this.pagedData = [...this.sortedData];
 
-    if (this.paging) {
+    if (this.paging === 'classic') {
       const startIndex = this.currentPage * this.pageSize;
       const endIndex = startIndex + this.pageSize;
 

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -223,7 +223,7 @@ export interface Options {
   initialPage?: number;
   loadingType?: ('overlay' | 'linear');
   maxBodyHeight?: number | string;
-  paging?: boolean;
+  paging?: ('classic' | 'infinite' | 'disabled');
   grouping?: boolean;
   pageSize?: number;
   pageSizeOptions?: number[];


### PR DESCRIPTION
В рамках изменений на основе issue #8 было реализовано:

- Внедрение бесконечного скролла без добавления новых props
- Смена типа paging с boolean на enum: `'infinite' | 'classic' | 'disable'`, значение по умолчанию - `classic`
- Создание примера с работающим бесконечным скроллом
- Обновление документации: указание обязательных props для активации бесконечного скролла