### PR TITLE
Append type of infinity

### DIFF
--- a/README.md
+++ b/README.md
@@ -187,6 +187,7 @@ ReactDOM.render(<App />, document.getElementById("react-div"));
 
 Here is a example of using material-table with infinite scroll.
 For activating infinite scroll you need to set `maxBodyHeight` less than height of page of content and set `paging: infinite`. Also, you can use callback function `onChangePage` instead of data function, which will be usefull for integration with Redux store.
+If `infinityType` === 'append' (default value) response data is added to the end of the list, otherwise with 'replace' value the data is overwritten
 
 ```jsx
 import React, { Component } from "react";
@@ -217,6 +218,7 @@ class App extends Component {
             options={{
               maxBodyHeight: 200,
               paging: 'infinite',
+              infinityType: 'append',
             }}
             data={query => new Promise((resolve, reject) => {
               let url = 'https://reqres.in/api/users?'

--- a/README.md
+++ b/README.md
@@ -187,7 +187,7 @@ ReactDOM.render(<App />, document.getElementById("react-div"));
 
 Here is a example of using material-table with infinite scroll.
 For activating infinite scroll you need to set `maxBodyHeight` less than height of page of content and set `paging: infinite`. Also, you can use callback function `onChangePage` instead of data function, which will be usefull for integration with Redux store.
-If `infinityType` === 'append' (default value) response data is added to the end of the list, otherwise with 'replace' value the data is overwritten
+If `infinityChangePropPolicy` === 'append' (default value) response data is added to the end of the list, otherwise with 'replace' value the data is overwritten
 
 ```jsx
 import React, { Component } from "react";
@@ -218,7 +218,7 @@ class App extends Component {
             options={{
               maxBodyHeight: 200,
               paging: 'infinite',
-              infinityType: 'append',
+              infinityChangePropPolicy: 'append',
             }}
             data={query => new Promise((resolve, reject) => {
               let url = 'https://reqres.in/api/users?'

--- a/demo/demo.js
+++ b/demo/demo.js
@@ -71,6 +71,7 @@ for (let i = 0; i < 1; i++) {
 
 const App = () => {
   const tableRef = React.createRef();
+  const tableInfiniteRef = React.createRef();
 
   const [ filterType, setFilterType ] = React.useState('header');
 
@@ -250,8 +251,50 @@ const App = () => {
                 })
             })}
           />
+          <button onClick={() => tableInfiniteRef.current.onQueryChange()}>Refresh infinite table</button>
           <MaterialTable
-            title="Infinite Scroll Preview"
+              title="Infinite Scroll Preview Append"
+              tableRef={tableInfiniteRef}
+              columns={[
+                {
+                  title: 'Avatar',
+                  field: 'avatar',
+                  render: rowData => (
+                      <img
+                          style={{ height: 36, borderRadius: '50%' }}
+                          src={rowData.avatar}
+                      />
+                  ),
+                },
+                { title: 'Id', field: 'id' },
+                { title: 'First Name', field: 'first_name' },
+                { title: 'Last Name', field: 'last_name' },
+              ]}
+              options={{
+                maxBodyHeight: 200,
+                paging: 'infinite',
+                infinityType: 'append',
+              }}
+              data={query => new Promise((resolve, reject) => {
+                let url = 'https://reqres.in/api/users?'
+                url += 'per_page=' + query.pageSize
+                url += '&page=' + (query.page + 1)
+                url += '&delay=3'
+                fetch(url)
+                    .then(response => response.json())
+                    .then(result => {
+                      resolve({
+                        data: result.data,
+                        page: result.page - 1,
+                        totalCount: result.total,
+                      })
+                    })
+              })}
+          />
+          <button onClick={() => tableInfiniteRef.current.onQueryChange()}>Refresh infinite table</button>
+          <MaterialTable
+            title="Infinite Scroll Preview Replace"
+            tableRef={tableInfiniteRef}
             columns={[
               {
                 title: 'Avatar',
@@ -270,11 +313,14 @@ const App = () => {
             options={{
               maxBodyHeight: 200,
               paging: 'infinite',
+              infinityType: 'replace',
             }}
             data={query => new Promise((resolve, reject) => {
+              console.log('query = ', query)
               let url = 'https://reqres.in/api/users?'
-              url += 'per_page=' + query.pageSize
-              url += '&page=' + (query.page + 1)
+              url += 'per_page=' + (query.page + 2) * query.pageSize
+              url += '&page=1'
+              url += '&delay=3'
               fetch(url)
                 .then(response => response.json())
                 .then(result => {

--- a/demo/demo.js
+++ b/demo/demo.js
@@ -71,7 +71,8 @@ for (let i = 0; i < 1; i++) {
 
 const App = () => {
   const tableRef = React.createRef();
-  const tableInfiniteRef = React.createRef();
+  const tableInfiniteAppendRef = React.createRef();
+  const tableInfiniteReplaceRef = React.createRef();
 
   const [ filterType, setFilterType ] = React.useState('header');
 
@@ -251,10 +252,10 @@ const App = () => {
                 })
             })}
           />
-          <button onClick={() => tableInfiniteRef.current.onQueryChange()}>Refresh infinite table</button>
+          <button onClick={() => tableInfiniteAppendRef.current.onQueryChange()}>Refresh infinite table</button>
           <MaterialTable
               title="Infinite Scroll Preview Append"
-              tableRef={tableInfiniteRef}
+              tableRef={tableInfiniteAppendRef}
               columns={[
                 {
                   title: 'Avatar',
@@ -291,10 +292,10 @@ const App = () => {
                     })
               })}
           />
-          <button onClick={() => tableInfiniteRef.current.onQueryChange()}>Refresh infinite table</button>
+          <button onClick={() => tableInfiniteReplaceRef.current.onQueryChange()}>Refresh infinite table</button>
           <MaterialTable
             title="Infinite Scroll Preview Replace"
-            tableRef={tableInfiniteRef}
+            tableRef={tableInfiniteReplaceRef}
             columns={[
               {
                 title: 'Avatar',
@@ -316,7 +317,6 @@ const App = () => {
               infinityType: 'replace',
             }}
             data={query => new Promise((resolve, reject) => {
-              console.log('query = ', query)
               let url = 'https://reqres.in/api/users?'
               url += 'per_page=' + (query.page + 2) * query.pageSize
               url += '&page=1'

--- a/demo/demo.js
+++ b/demo/demo.js
@@ -274,7 +274,7 @@ const App = () => {
               options={{
                 maxBodyHeight: 200,
                 paging: 'infinite',
-                infinityType: 'append',
+                infinityChangePropPolicy: 'append',
               }}
               data={query => new Promise((resolve, reject) => {
                 let url = 'https://reqres.in/api/users?'
@@ -314,7 +314,7 @@ const App = () => {
             options={{
               maxBodyHeight: 200,
               paging: 'infinite',
-              infinityType: 'replace',
+              infinityChangePropPolicy: 'replace',
             }}
             data={query => new Promise((resolve, reject) => {
               let url = 'https://reqres.in/api/users?'

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@softmedialab/materialui-table",
-  "version": "1.0.49",
+  "version": "1.0.50",
   "description": "Datatable for React based on https://material-table.com with additional features",
   "main": "dist/index.js",
   "types": "types/index.d.ts",

--- a/src/material-table.js
+++ b/src/material-table.js
@@ -84,7 +84,7 @@ export default class MaterialTable extends React.Component {
     isInit && this.dataManager.changeCurrentPage(props.options.initialPage ? props.options.initialPage : 0);
     isInit && this.dataManager.changePageSize(props.options.pageSize);
     isInit && this.dataManager.changePaging(props.options.paging);
-    isInit && this.dataManager.changeInfinityType(props.options.infinityType || 'append');
+    isInit && this.dataManager.changeInfinityType(props.options.infinityChangePropPolicy || 'append');
     isInit && this.dataManager.changeParentFunc(props.parentChildData);
     this.dataManager.changeDetailPanelType(props.options.detailPanelType);
   }

--- a/src/material-table.js
+++ b/src/material-table.js
@@ -84,6 +84,7 @@ export default class MaterialTable extends React.Component {
     isInit && this.dataManager.changeCurrentPage(props.options.initialPage ? props.options.initialPage : 0);
     isInit && this.dataManager.changePageSize(props.options.pageSize);
     isInit && this.dataManager.changePaging(props.options.paging);
+    isInit && this.dataManager.changeInfinityType(props.options.infinityType || 'append');
     isInit && this.dataManager.changeParentFunc(props.parentChildData);
     this.dataManager.changeDetailPanelType(props.options.detailPanelType);
   }

--- a/src/utils/data-manager.js
+++ b/src/utils/data-manager.js
@@ -13,7 +13,7 @@ export default class DataManager {
   orderDirection = '';
   pageSize = 5;
   paging = 'classic';
-  infinityType = 'append';
+  infinityChangePropPolicy = 'append';
   parentFunc = null;
   searchText = '';
   selectedCount = 0;
@@ -63,7 +63,7 @@ export default class DataManager {
       }
       return row;
     });
-    if (this.paging === 'infinite' && this.infinityType === 'append') {
+    if (this.paging === 'infinite' && this.infinityChangePropPolicy === 'append') {
       this.data = this.data.concat(dataMapped);
     } else {
       this.data = dataMapped;
@@ -122,8 +122,8 @@ export default class DataManager {
     this.paged = false;
   }
 
-  changeInfinityType(infinityType) {
-    this.infinityType = infinityType;
+  changeInfinityType(infinityChangePropPolicy) {
+    this.infinityChangePropPolicy = infinityChangePropPolicy;
   }
 
   changeCurrentPage(currentPage) {

--- a/src/utils/data-manager.js
+++ b/src/utils/data-manager.js
@@ -13,6 +13,7 @@ export default class DataManager {
   orderDirection = '';
   pageSize = 5;
   paging = 'classic';
+  infinityType = 'append';
   parentFunc = null;
   searchText = '';
   selectedCount = 0;
@@ -62,7 +63,7 @@ export default class DataManager {
       }
       return row;
     });
-    if (this.paging === 'infinite') {
+    if (this.paging === 'infinite' && this.infinityType === 'append') {
       this.data = this.data.concat(dataMapped);
     } else {
       this.data = dataMapped;
@@ -119,6 +120,10 @@ export default class DataManager {
   changePaging(paging) {
     this.paging = paging;
     this.paged = false;
+  }
+
+  changeInfinityType(infinityType) {
+    this.infinityType = infinityType;
   }
 
   changeCurrentPage(currentPage) {

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -224,6 +224,7 @@ export interface Options {
   loadingType?: ('overlay' | 'linear');
   maxBodyHeight?: number | string;
   paging?: ('classic' | 'infinite' | 'disabled');
+  infinityChangePropPolicy?: ('append' | 'replace');
   grouping?: boolean;
   pageSize?: number;
   pageSizeOptions?: number[];


### PR DESCRIPTION
Исправляет ошибку, которая возникает при работе бесконечного скролла при внешнем вызове onQueryChange(), при котором список дублируется за счет использования concut(). Теперь есть вариант использования, где при обновлении запрашиваются данные с 0 страницы по текущую. Это в том числе исправляет ситуацию, когда данные обновились.